### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,3 @@ The cluster synchronization occurs across different clusters and the same namesp
 You need to specify the cluster names using the annotation below:
 
 `keess.powerhrg.com/clusters: clustera, clusterb, clusterc`
-
-## Known flaws
-
-Changes made to synchronised resources while Keess is bootstrapping may not be detected and synchronised. Restarting the service should catch up if synchronisation is found to be behind as a result.


### PR DESCRIPTION
Removing the know flaws section because when the watcher starts it picks up all the changes from the beginning, that is, if something happens between the end of the bootstrap and the start of the watcher, it will pick it up. There is no flaw.