### PR TITLE
Fixes the bug when we update target clusters in cross-cluster sync.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,8 +7,8 @@ app.build(
   resources: [
     requestCpu: "3",
     limitCpu: "5",
-    requestMemory: "8Gi",
-    limitMemory: "8Gi",
+    requestMemory: "2Gi",
+    limitMemory: "2Gi",
     requestStorage: '50Gi',
     limitStorage: '50Gi',
   ],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,8 +9,8 @@ app.build(
     limitCpu: "5",
     requestMemory: "2Gi",
     limitMemory: "2Gi",
-    requestStorage: '50Gi',
-    limitStorage: '50Gi',
+    requestStorage: '10Gi',
+    limitStorage: '10Gi',
   ],
   agentResources: [
     limitCpu: "1.5",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,26 @@
 
 library 'github.com/powerhome/ci-kubed@v6.10.1'
 
-app.build([:]) {
+app.build(
+  cluster: [:],
+  resources: [
+    requestCpu: "3",
+    limitCpu: "5",
+    requestMemory: "8Gi",
+    limitMemory: "8Gi",
+    requestStorage: '50Gi',
+    limitStorage: '50Gi',
+  ],
+  agentResources: [
+    limitCpu: "1.5",
+    limitMemory: "1Gi",
+    logLevel: "FINEST",
+    heapSize: "768m",
+  ],
+  preferDiskAtLeast: 5,
+  requireDiskAtLeast: 1,
+  timeout: 200,
+) {
   app.composeBuild(
     appRepo: "image-registry.powerapp.cloud/keess/keess",
   ) { compose ->

--- a/application/application.go
+++ b/application/application.go
@@ -11,7 +11,7 @@ import (
 func New() *cli.App {
 	app := cli.NewApp()
 	app.Name = "Keess"
-	app.Version = "v0.1.5"
+	app.Version = "v0.1.6"
 	app.Usage = "Keep stuff synchronized."
 	app.Description = "Keep secrets and configmaps synchronized."
 	app.Suggest = true

--- a/kube_syncer/abstractions/kubernetes_entity.go
+++ b/kube_syncer/abstractions/kubernetes_entity.go
@@ -106,7 +106,17 @@ func (e *KubernetesEntity) Update() error {
 		if error == nil {
 			Logger.Infof("The configmap '%s' was updated in the namespace '%s' on context '%s'.", entity.Name, entity.Namespace, e.DestinationContext)
 		} else {
-			Logger.Debug(error)
+			if !errorsTypes.IsNotFound(error) {
+				Logger.Error(error)
+			} else {
+				// If not exists it need to be updated.
+				_, error := client.Create(context.TODO(), entity, v1.CreateOptions{})
+				if error == nil {
+					Logger.Infof("The configmap '%s' was created in the namespace '%s' on context '%s'.", entity.Name, entity.Namespace, e.DestinationContext)
+				} else {
+					Logger.Error(error)
+				}
+			}
 		}
 
 		return error
@@ -123,7 +133,17 @@ func (e *KubernetesEntity) Update() error {
 		if error == nil {
 			Logger.Infof("The secret '%s' was updated in the namespace '%s' on context '%s'.", entity.Name, entity.Namespace, e.DestinationContext)
 		} else {
-			Logger.Debug(error)
+			if !errorsTypes.IsNotFound(error) {
+				Logger.Error(error)
+			} else {
+				// If not exists it need to be updated.
+				_, error := client.Create(context.TODO(), entity, v1.CreateOptions{})
+				if error == nil {
+					Logger.Infof("The secret '%s' was created in the namespace '%s' on context '%s'.", entity.Name, entity.Namespace, e.DestinationContext)
+				} else {
+					Logger.Error(error)
+				}
+			}
 		}
 
 		return error


### PR DESCRIPTION
When we create a Secret or Configmap synced across clusters and then added a new cluster, Keess was failing as it was trying to update an artifact that didn't exist on the new target cluster. Now when it gets a 404 it handles the error and creates the artifact on this new cluster.