### PR TITLE
Stop crashing when losing connection

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -11,7 +11,7 @@ import (
 func New() *cli.App {
 	app := cli.NewApp()
 	app.Name = "Keess"
-	app.Version = "v0.1.8"
+	app.Version = "v0.1.9"
 	app.Usage = "Keep stuff synchronized."
 	app.Description = "Keep secrets and configmaps synchronized."
 	app.Suggest = true

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.8
+version: 0.1.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.1.8"
+appVersion: "v0.1.9"

--- a/kube_syncer/abstractions/abstractions.go
+++ b/kube_syncer/abstractions/abstractions.go
@@ -50,6 +50,9 @@ var EntitiesToAllNamespaces map[string]map[string]runtime.Object = make(map[stri
 // A map containing the ConfigMaps that sould be present in every Namespace that matches with the configured label
 var EntitiesToLabeledNamespaces map[string]map[string]runtime.Object = make(map[string]map[string]runtime.Object)
 
+// Slice containing the connected clusters.
+var ConnectedClusters []string = []string{}
+
 // === Functions === //
 
 // Check if exists a valid annotation in an annotation map.

--- a/kube_syncer/abstractions/configmap_event.go
+++ b/kube_syncer/abstractions/configmap_event.go
@@ -56,11 +56,16 @@ func (c ConfigMapEvent) Sync(sourceContext string, kubeClients *map[string]*kube
 
 					if namespace.Labels[label] == strings.Trim(value, "\"") {
 						namespaces = append(namespaces, namespaceName)
-						Logger.Debugf("The namespace '%s' contains the synchronization label '%s'. The configmap '%s' will be synchronized.", namespaceName, namespaceLabelAnnotation, configMap.Name)
+						Logger.Debugf("The namespace '%s' contains the synchronization label '%s'. The configMap '%s' will be synchronized.", namespaceName, namespaceLabelAnnotation, configMap.Name)
 					}
+
 				}
 				EntitiesToLabeledNamespaces["ConfigMaps"][configMap.Name] = configMap
 			}
+		}
+
+		if c.Type == Deleted {
+			delete(EntitiesToAllNamespaces["ConfigMaps"], configMap.Name)
 		}
 
 		for _, destinationNamespace := range namespaces {
@@ -87,6 +92,17 @@ func (c ConfigMapEvent) Sync(sourceContext string, kubeClients *map[string]*kube
 		annotation := configMap.Annotations[ClusterAnnotation]
 		clusters := StringToSlice(annotation)
 
+		var removedClusters []string = []string{}
+		for _, destinationContext := range ConnectedClusters {
+			contains := false
+			for _, cluster := range clusters {
+				contains = contains || cluster == destinationContext
+			}
+			if !contains {
+				removedClusters = append(removedClusters, destinationContext)
+			}
+		}
+
 		for _, destinationContext := range clusters {
 			if sourceContext == destinationContext {
 				continue
@@ -102,6 +118,11 @@ func (c ConfigMapEvent) Sync(sourceContext string, kubeClients *map[string]*kube
 			case Deleted:
 				kubeEntity.Delete()
 			}
+		}
+
+		for _, removedCluster := range removedClusters {
+			kubeEntity := NewKubernetesEntity(*kubeClients, configMap, ConfigMapEntity, sourceNamespace, sourceNamespace, sourceContext, removedCluster)
+			kubeEntity.Delete()
 		}
 	}
 

--- a/kube_syncer/syncer.go
+++ b/kube_syncer/syncer.go
@@ -22,6 +22,9 @@ import (
 	"k8s.io/client-go/util/homedir"
 )
 
+// Slice containing the connected clusters.
+var ConnectedClusters []string = []string{}
+
 // Represents a base structure for any syncer.
 type Syncer struct {
 	kubeClients map[string]*kubernetes.Clientset
@@ -111,6 +114,7 @@ func (s *Syncer) Start(kubeConfigPath string, developmentMode bool, sourceContex
 
 	s.kubeClients = map[string]*kubernetes.Clientset{}
 	s.kubeClients[s.sourceContext] = client
+	abstractions.ConnectedClusters = destinationContexts
 
 	for _, context := range destinationContexts {
 		config, err := buildConfigWithContextFromFlags(context, *kubeconfig)


### PR DESCRIPTION
This PR contains two changes:

1. Stop crashing when losing connection with some cluster.
2. In cross-cluster synchronization, the artifact on the target cluster is now deleted when this cluster is removed from the configuration annotation on the source cluster.