### PR TITLE
Parameterize deployment probes

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       - name: config
         secret:
           secretName: {{ template "keess.fullname" . }}
-          defaultMode: 420        
+          defaultMode: 420
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -38,7 +38,7 @@ spec:
           env:
           - name: KEESS_SOURCE_CONTEXT
             value: "{{ .Values.clusterName }}"
-          {{- if .Values.remoteClusters }}  
+          {{- if .Values.remoteClusters }}
           - name: KEESS_DESTINATION_CONTEXTS
             value: "{{ .Values.remoteClusters }}"
           {{- end }}
@@ -49,7 +49,7 @@ spec:
           {{- if .Values.logLevel }}
           - name: LOG_LEVEL
             value: "{{ .Values.logLevel }}"
-          {{- end }}          
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
           - name: config
@@ -60,13 +60,9 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           livenessProbe:
-            httpGet:
-              path: /health
-              port: http
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /health
-              port: http
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -54,6 +54,15 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
# Description
Add the possibility to update `livenessProbe` and `redinessProbe`.

Here is a test `helm template` output
```yaml
(⎈|kind-kind:N/A)➜  keess git:(fix/parameterize-probes) pac helm template test ./chart                                                                                                                   [9/02/24 | 11:07:32]
---
# Source: keess/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: keess
  namespace: default
  labels:
    helm.sh/chart: keess-0.2.14
    app.kubernetes.io/name: keess
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "0.2.14"
    app.kubernetes.io/managed-by: Helm
---
# Source: keess/templates/cluster-role.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: test-keess
  labels:
    helm.sh/chart: keess-0.2.14
    app.kubernetes.io/name: keess
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "0.2.14"
    app.kubernetes.io/managed-by: Helm
rules:
- apiGroups: [""]
  resources:
  - configmaps
  - secrets
  verbs: ["get", "create", "update", "patch", "delete", "list", "watch"]
- apiGroups: [""]
  resources:
  - namespaces
  verbs: ["get", "list", "watch"]
- apiGroups: [""]
  resources:
  - nodes
  verbs: ["list"]
- apiGroups: [""]
  resources:
  - events
  verbs: ["create"]
---
# Source: keess/templates/cluster-role-binding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: test-keess
  labels:
    helm.sh/chart: keess-0.2.14
    app.kubernetes.io/name: keess
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "0.2.14"
    app.kubernetes.io/managed-by: Helm
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: test-keess
subjects:
- kind: ServiceAccount
  name: keess
  namespace: default
---
# Source: keess/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test-keess
  namespace: default
  labels:
    helm.sh/chart: keess-0.2.14
    app.kubernetes.io/name: keess
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "0.2.14"
    app.kubernetes.io/managed-by: Helm
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: keess
      app.kubernetes.io/instance: test
  template:
    metadata:
      labels:
        app.kubernetes.io/name: keess
        app.kubernetes.io/instance: test
    spec:
      serviceAccountName: keess
      securityContext:
        {}
      volumes:
      - name: config
        secret:
          secretName: test-keess
          defaultMode: 420
      containers:
        - name: keess
          securityContext:
            {}
          image: "image-registry.powerapp.cloud/keess/keess:0.2.14"
          env:
          - name: KEESS_SOURCE_CONTEXT
            value: ""
          imagePullPolicy: IfNotPresent
          volumeMounts:
          - name: config
            mountPath: /root/.kube
            readOnly: true
          ports:
            - name: http
              containerPort: 8080
              protocol: TCP
          livenessProbe:
            httpGet:
              path: /health
              port: http
          readinessProbe:
            httpGet:
              path: /health
              port: http
          resources:
            {}
```