### PR TITLE
Bump ci-kubed v8.6.0 [no-cache]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library 'github.com/powerhome/ci-kubed@v8.2.0'
+library 'github.com/powerhome/ci-kubed@v8.5.1'
 
 app.build(
   cluster: [:],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library 'github.com/powerhome/ci-kubed@v8.5.1'
+library 'github.com/powerhome/ci-kubed@v8.6.0'
 
 app.build(
   cluster: [:],


### PR DESCRIPTION
This bumps ci-kubed to the latest version, which includes optimizations to the image build phase and the ability to specify remote builder resources per project and independently of the rest of the pipeline.