### PR TITLE
Detect differences in secret contents

### DIFF
--- a/pkg/services/pac_secret.go
+++ b/pkg/services/pac_secret.go
@@ -1,6 +1,9 @@
 package services
 
 import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -48,5 +51,20 @@ func (s *PacSecret) HasChanged(remote v1.Secret) bool {
 		return true
 	}
 
+	if Digest(s.Secret.Data) != Digest(remote.Data) {
+		return true
+	}
+
 	return false
+}
+
+func Digest(data map[string][]byte) string {
+	contents, err := json.Marshal(data)
+	if err != nil {
+		// TODO: What should we do if we fail to marshall the data
+		// property for digestion?
+		return ""
+	}
+
+	return fmt.Sprintf("%x", sha256.Sum256(contents))
 }


### PR DESCRIPTION
Summary:

Enhance change detection of secrets by comparing the digest of contents.

This also restructures the TestHasChanged scenarios in pac_secret_test.go to decouple the implementation from the order in which those example run. It is also meant to expose which parts of the remote resource are important to the individual scenario / reduce duplication.

Context:

I recently ran into a case where datastore replication broke down because a TLS cert - managed by keess - used to establish the replication channel was out of sync between two Kube clusters. The existing checks were not enough to detect that the contents were out of sync.

```
$ kubectl --context source-cluster --namespace example-namespace describe secrets/database-cert-secret
Name:         database-cert-secret
Namespace:    example-namespace
Labels:
...
              keess.powerhrg.com/sync=cluster
Annotations:
...
              keess.powerhrg.com/clusters: remote-cluster
...
Type:  kubernetes.io/tls
...
Data
====
ca.crt:   1115 bytes
tls.crt:  1549 bytes
tls.key:  1679 bytes
```

```
$ kubectl --context remote-cluster --namespace example-namespace describe secrets/database-cert-secret
Name:         database-cert-secret
Namespace:    example-namespace
Labels:
...
              keess.powerhrg.com/managed=true
Annotations:
...
              keess.powerhrg.com/source-cluster: source-cluster
              keess.powerhrg.com/source-namespace: example-namespace
              keess.powerhrg.com/source-resource-version: 3930450375
...
Type:  kubernetes.io/tls
...
Data
====
ca.crt:   1090 bytes
tls.crt:  1208 bytes
tls.key:  1679 bytes
```

I'm not sure how/why the contents of the secrets had changed, but is seems like keess should have caught that the source secret had changed and resynced.