### PR TITLE
Don't select PAC nodes based on local disk

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,8 +18,6 @@ app.build(
     logLevel: "FINEST",
     heapSize: "768m",
   ],
-  preferDiskAtLeast: 5,
-  requireDiskAtLeast: 1,
   timeout: 200,
 ) {
   app.composeBuild(


### PR DESCRIPTION
All PAC nodes have good local disk these days. This was a performance optimisation from when we had a bunch of legacy hardware as part of PAC, and the complexity is unnecessary now.

This is necessary for the next release of `ci-kubed` to work:
https://github.com/powerhome/ci-kubed/pull/216