### PR TITLE
Adopts renovate grouping of non major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>powerhome/renovate-config"
+    "local>powerhome/renovate-config",
+    "group:allNonMajor"
   ]
 }


### PR DESCRIPTION
Renovate generates lots of PRs here. It's unecessary noise on this repo. More grouping will ease management.