### PR TITLE
Error on service type different from ClusterIP

### DIFF
--- a/examples/wrong/test-service-sync-example-not-clusterip.yaml
+++ b/examples/wrong/test-service-sync-example-not-clusterip.yaml
@@ -1,0 +1,43 @@
+# Example: Service Synchronization with Keess for E2E testing
+# This is a simplified version of the service-sync example for testing purposes
+
+---
+# Service on Source Cluster
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-svc
+  namespace: test-keess-service
+  labels:
+    keess.powerhrg.com/sync: "cluster"  # Enable cluster sync for this service
+  annotations:
+    service.cilium.io/global: "true"    # Enable Cilium Global Service
+    keess.powerhrg.com/clusters: "kind-destination-cluster"  # Target cluster for testing
+spec:
+  ports:
+  - name: mysql
+    port: 3306
+    protocol: TCP
+    targetPort: 3306
+  selector:
+    app.kubernetes.io/component: mysql
+  type: LoadBalancer
+
+---
+# Pod that the service selects (for demonstration)
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mysql-pod
+  namespace: test-keess-service
+  labels:
+    app.kubernetes.io/component: mysql
+spec:
+  containers:
+  - name: mysql
+    image: mysql:8.0
+    ports:
+    - containerPort: 3306
+    env:
+    - name: MYSQL_ROOT_PASSWORD
+      value: "example"

--- a/pkg/keess/service/service_synchronizer.go
+++ b/pkg/keess/service/service_synchronizer.go
@@ -100,7 +100,6 @@ func (s *ServiceSynchronizer) sync(ctx context.Context, pacService PacService) e
 	// Check sync label is set to "cluster"
 	syncMode, exists := pacService.Service.Labels[keess.LabelSelector]
 	if !exists || syncMode != "cluster" {
-		// TODO: unit test
 		s.logger.Error("[Service][sync] Service sync requires cluster sync mode, skipping sync: ", pacService.Service.Name)
 		return nil
 	}
@@ -108,13 +107,11 @@ func (s *ServiceSynchronizer) sync(ctx context.Context, pacService PacService) e
 	// Check if the service has the clusters annotation
 	clustersAnnotation, exists := pacService.Service.Annotations[keess.ClusterAnnotation]
 	if !exists {
-		// TODO: unit test
 		s.logger.Debug("[Service][sync] Service is marked for sync but does not have clusters annotation, skipping sync: ", pacService.Service.Name)
 		return nil
 	}
 
 	if pacService.Service.Spec.Type != corev1.ServiceTypeClusterIP {
-		// TODO: unit test
 		s.logger.Error("[Service][sync] Only ClusterIP services are supported for sync, skipping sync: ", pacService.Service.Name)
 		return nil
 	}
@@ -125,7 +122,6 @@ func (s *ServiceSynchronizer) sync(ctx context.Context, pacService PacService) e
 	// Sync to each cluster
 	for _, cluster := range clusters {
 		if cluster == pacService.Cluster {
-			// TODO: unit test
 			s.logger.Debug("[Service][sync] Service is marked for sync to its own cluster, skipping remote sync: ", pacService.Service.Name)
 		} else {
 			// Sync remotely

--- a/pkg/keess/service/service_synchronizer_test.go
+++ b/pkg/keess/service/service_synchronizer_test.go
@@ -1,0 +1,228 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"keess/pkg/keess"
+)
+
+// Helper function to create a basic test service with configurable metadata
+func createTestService(name, namespace string, labels map[string]string, annotations map[string]string, serviceType corev1.ServiceType) corev1.Service {
+	return corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Spec: corev1.ServiceSpec{
+			Type: serviceType,
+			Ports: []corev1.ServicePort{
+				{
+					Name:     "http",
+					Port:     80,
+					Protocol: corev1.ProtocolTCP,
+				},
+			},
+		},
+	}
+}
+
+// Helper function to create a ServiceSynchronizer with mock clients
+func createTestSynchronizer() (*ServiceSynchronizer, map[string]keess.IKubeClient) {
+	logger := zap.NewNop().Sugar()
+	localClient := &keess.MockKubeClient{Clientset: fake.NewSimpleClientset()}
+	remoteClients := map[string]keess.IKubeClient{
+		"cluster1": &keess.MockKubeClient{Clientset: fake.NewSimpleClientset()},
+		"cluster2": &keess.MockKubeClient{Clientset: fake.NewSimpleClientset()},
+	}
+
+	synchronizer := NewServiceSynchronizer(
+		localClient,
+		remoteClients,
+		nil, // servicePoller not needed for this test
+		nil, // namespacePoller not needed for this test
+		logger,
+	)
+
+	return synchronizer, remoteClients
+}
+
+// Helper function to create a ServiceSynchronizer with pre-existing namespaces
+func createTestSynchronizerWithNamespaces(namespace string) (*ServiceSynchronizer, map[string]keess.IKubeClient) {
+	logger := zap.NewNop().Sugar()
+	localClient := &keess.MockKubeClient{Clientset: fake.NewSimpleClientset()}
+
+	// Create remote clients with the target namespace already existing
+	remoteClient1 := fake.NewSimpleClientset()
+	remoteClient2 := fake.NewSimpleClientset()
+
+	// Create the namespace in remote clusters
+	testNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+		},
+	}
+	remoteClient1.CoreV1().Namespaces().Create(context.Background(), testNamespace, metav1.CreateOptions{})
+	remoteClient2.CoreV1().Namespaces().Create(context.Background(), testNamespace, metav1.CreateOptions{})
+
+	remoteClients := map[string]keess.IKubeClient{
+		"cluster1": &keess.MockKubeClient{Clientset: remoteClient1},
+		"cluster2": &keess.MockKubeClient{Clientset: remoteClient2},
+	}
+
+	synchronizer := NewServiceSynchronizer(
+		localClient,
+		remoteClients,
+		nil, // servicePoller not needed for this test
+		nil, // namespacePoller not needed for this test
+		logger,
+	)
+
+	return synchronizer, remoteClients
+}
+
+// Helper function to verify that no services were synced to remote clusters
+func verifyNoServicesSynced(t *testing.T, remoteClients map[string]keess.IKubeClient, namespace string) {
+	for clusterName, client := range remoteClients {
+		services, err := client.CoreV1().Services(namespace).List(context.Background(), metav1.ListOptions{})
+		if err != nil {
+			t.Errorf("Failed to list services in cluster %s: %v", clusterName, err)
+		}
+		if len(services.Items) != 0 {
+			t.Errorf("Expected no services in cluster %s, but found %d", clusterName, len(services.Items))
+		}
+	}
+}
+
+// Helper function to test invalid sync cases
+func testInvalidSyncCase(t *testing.T, testName string, service corev1.Service) {
+	pacService := PacService{
+		Cluster: "source-cluster",
+		Service: service,
+	}
+
+	synchronizer, remoteClients := createTestSynchronizer()
+
+	// Call sync - should return nil (no error) but skip processing
+	err := synchronizer.sync(context.Background(), pacService)
+	if err != nil {
+		t.Errorf("[%s] Expected no error, got %v", testName, err)
+	}
+
+	// Verify service was not synced to remote clusters
+	verifyNoServicesSynced(t, remoteClients, service.Namespace)
+}
+
+func TestServiceSynchronizer_Sync_InvalidSyncMode(t *testing.T) {
+	service := createTestService(
+		"test-service",
+		"test-namespace",
+		map[string]string{
+			keess.LabelSelector: "namespace", // Not "cluster"
+		},
+		map[string]string{
+			keess.ClusterAnnotation: "cluster1,cluster2",
+		},
+		corev1.ServiceTypeClusterIP,
+	)
+
+	testInvalidSyncCase(t, "InvalidSyncMode", service)
+}
+
+func TestServiceSynchronizer_Sync_MissingLabelSelector(t *testing.T) {
+	service := createTestService(
+		"test-service",
+		"test-namespace",
+		map[string]string{}, // No sync label
+		map[string]string{
+			keess.ClusterAnnotation: "cluster1,cluster2",
+		},
+		corev1.ServiceTypeClusterIP,
+	)
+
+	testInvalidSyncCase(t, "MissingLabelSelector", service)
+}
+
+func TestServiceSynchronizer_Sync_MissingClustersAnnotation(t *testing.T) {
+	service := createTestService(
+		"test-service",
+		"test-namespace",
+		map[string]string{
+			keess.LabelSelector: "cluster",
+		},
+		map[string]string{}, // No clusters annotation
+		corev1.ServiceTypeClusterIP,
+	)
+
+	testInvalidSyncCase(t, "MissingClustersAnnotation", service)
+}
+
+func TestServiceSynchronizer_Sync_NonClusterIPService(t *testing.T) {
+	service := createTestService(
+		"test-service",
+		"test-namespace",
+		map[string]string{
+			keess.LabelSelector: "cluster",
+		},
+		map[string]string{
+			keess.ClusterAnnotation: "cluster1,cluster2",
+		},
+		corev1.ServiceTypeNodePort, // Not ClusterIP
+	)
+
+	testInvalidSyncCase(t, "NonClusterIPService", service)
+}
+
+func TestServiceSynchronizer_Sync_ValidService(t *testing.T) {
+	service := createTestService(
+		"test-service",
+		"test-namespace",
+		map[string]string{
+			keess.LabelSelector: "cluster",
+		},
+		map[string]string{
+			keess.ClusterAnnotation: "cluster1,cluster2",
+		},
+		corev1.ServiceTypeClusterIP,
+	)
+
+	pacService := PacService{
+		Cluster: "source-cluster",
+		Service: service,
+	}
+
+	synchronizer, remoteClients := createTestSynchronizerWithNamespaces("test-namespace")
+
+	// Call sync - should successfully sync to remote clusters
+	err := synchronizer.sync(context.Background(), pacService)
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	// Verify service was synced to remote clusters
+	for clusterName, client := range remoteClients {
+		services, err := client.CoreV1().Services("test-namespace").List(context.Background(), metav1.ListOptions{})
+		if err != nil {
+			t.Errorf("Failed to list services in cluster %s: %v", clusterName, err)
+		}
+		if len(services.Items) != 1 {
+			t.Errorf("Expected 1 service in cluster %s, but found %d", clusterName, len(services.Items))
+		}
+		if len(services.Items) > 0 {
+			syncedService := services.Items[0]
+			if syncedService.Name != "test-service" {
+				t.Errorf("Expected service name 'test-service' in cluster %s, got %s", clusterName, syncedService.Name)
+			}
+			if syncedService.Labels[keess.ManagedLabelSelector] != "true" {
+				t.Errorf("Expected managed label to be 'true' in cluster %s, got %s", clusterName, syncedService.Labels[keess.ManagedLabelSelector])
+			}
+		}
+	}
+}


### PR DESCRIPTION
The new Service sync feature only makes sense for us with ClusterIP service type (at least for now). Even Cilium may support only that type in its global service feature. 

So instead of investigating and adapting to other service types, we decided to just error out (but keep processing of other services, of course) if another type is set.

This PR also adds some unit tests (mostly AI generated) for service synchronizer.