### PR TITLE
Fix typo on service-sync docs

### DIFF
--- a/docs/service-sync.md
+++ b/docs/service-sync.md
@@ -6,7 +6,7 @@ The purpose of this feature is to facilitate exposing a service in one cluster t
 
 When you use [Cilium](https://docs.cilium.io/en/latest/overview/intro/) CNI in multiple related Kubernetes Clusters, you can use its ClusterMesh features to extend networking across them.
 
-When using a ClusterMesh, you cant load balance Kubernetes services over the clusters, or **expose a service on one cluster as a local service on the other ones**. Is this later use case that this Keess feature targets, to make it easier for our users to configure such service exposure across clusters.
+When using a ClusterMesh, you can load balance Kubernetes services over the clusters, or **expose a service on one cluster as a local service on the other ones**. Is this later use case that this Keess feature targets, to make it easier for our users to configure such service exposure across clusters.
 
 Cilium enables that through the concept of [Global Services](https://docs.cilium.io/en/latest/network/clustermesh/services/#load-balancing-with-global-services). They are primarily made to balance across service instances deployed to many clusters. It will expose the remote endpoints inside each cluster's local service.
 


### PR DESCRIPTION
Found a small typo in the docs.