### PR TITLE
fix: update helm chart to add replicaCount

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.1
+version: 1.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "keess.labels" . | nindent 4 }}
 spec:
+  replicas: {{ .Values.replicaCount | default 1 }}
   selector:
     matchLabels:
       {{- include "keess.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
## 🚀 What does this PR do?

Adds an explicit `spec.replicas` field to the `Deployment` template (`chart/templates/deployment.yaml`), wiring it to the Helm value `replicaCount` (defaulting to 1). Bumps the Helm chart version from `1.3.1` to `1.3.2`.

## 🔍 Why? (Context)

Previously the chart did not set `spec.replicas`, which meant:
- Users could not override replica count via `--set replicaCount=` (Helm value existed but was unused).
- Some environments might rely on HPA or manual scaling later, but having a chart-driven initial replica count improves consistency and supports intentional scaling config at deploy time.
This change makes the chart’s `replicaCount` value effective and clarifies expected behavior without changing application code.

## Checklist

- [x] Update the Helm chart version and/or appVersion if those are changed  
      (Chart `version` bumped to `1.3.2`; `appVersion` remains `1.3.0` intentionally)
- [ ] Update `cmd/version.go` if code was changed  
      (Not needed: no Go source changes)
- [ ] Publish the new `keess` image  
      (Not needed: no binary/code changes; template-only update)
- [ ] Publish the new `kubeconfig-reloader` image  
      (Not needed: no changes related to reloader)
- [ ] Updated `docs/` or `README.md` if needed  
      (Not needed: behavior is self-explanatory; can add a usage note if desired)

## 🧪 How this was tested? And test results

```sh
# Package (optional)
helm lint chart/
helm template test-release chart/ --set replicaCount=3 | grep -A3 'kind: Deployment' | grep replicas

# Install with override
helm install rc-test chart/ --set replicaCount=2
kubectl get deploy -l app.kubernetes.io/name=keess -o jsonpath='{.items[0].spec.replicas}'
# Expect: 2

# Override again
helm upgrade rc-test chart/ --set replicaCount=4
kubectl get deploy -l app.kubernetes.io/name=keess -o jsonpath='{.items[0].spec.replicas}'
# Expect: 4