### PR TITLE
chore(deps): Update ci-kubed library version to v9.8.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library 'github.com/powerhome/ci-kubed@v8.6.0'
+library 'github.com/powerhome/ci-kubed@v9.8.0'
 
 app.build(
   cluster: [:],


### PR DESCRIPTION
## 🚀 What does this PR do?
This updates the ci-kubed version to v9.8.0.

## 🔍 Why? (Context)
Builds using Jenkins will start encountering issues without this ci-kubed upgrade.

## Checklist

<!--
this is here to help you REMEMBER to:
-->
- [ ] Update the Helm chart version and/or appVersion if those are changed
- [ ] Update cmd/version.go if code was changed
- [ ] Publish the new keess image
- [ ] Publish the new kubeconfig-reloader image
- [ ] Updated docs/ or /README.md if needed

## 🧪 How this was tested? And test results
<!--
- Remember to test on alpha, unless it does not apply (docs, workflows, etc.).
- How can the reviewer test it? Commands, etc.
- Also add test evidences if possible, showing it works.
-->

`Tested on alpha environment (or test not needed).`

## ⚠️ Special care or coordination needed?
<!--
- Do we need to coordinate merge with other PRs? List them here.
- Do we need to coordinate or add changes to external resources (F5, AWS, etc?) mention them here
- Is it a risk operation that may cause service interruption? Do we need an implementation plan?
-->

`No special care needed.`
