### PR TITLE
feat(release): automate image releases with GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: self-hosted
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Login to Harbor Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: image-registry.powerapp.cloud
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_PASSWORD }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,91 @@
+version: 2
+
+project_name: keess
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: keess
+    main: .
+    binary: keess
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+
+archives:
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  name_template: "checksums.txt"
+  algorithm: sha256
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^ci:'
+      - '^chore:'
+      - Merge pull request
+      - Merge branch
+
+dockers:
+  - id: keess
+    use: buildx
+    dockerfile: Dockerfile
+    image_templates:
+      - "image-registry.powerapp.cloud/keess/keess:{{ .Version }}"
+      - "image-registry.powerapp.cloud/keess/keess:latest"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--push"
+      - "--label=org.opencontainers.image.title=keess"
+      - "--label=org.opencontainers.image.source=https://github.com/powerhome/keess"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+    extra_files:
+      - go.mod
+      - go.sum
+      - main.go
+      - cmd
+      - pkg
+
+  - id: kubeconfig-reloader
+    use: buildx
+    dockerfile: Dockerfile.kubeconfig-reloader
+    image_templates:
+      - "image-registry.powerapp.cloud/keess/keess-kubeconfig-reloader:{{ .Version }}"
+      - "image-registry.powerapp.cloud/keess/keess-kubeconfig-reloader:latest"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--push"
+      - "--label=org.opencontainers.image.title=keess-kubeconfig-reloader"
+      - "--label=org.opencontainers.image.source=https://github.com/powerhome/keess"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+    extra_files:
+      - extra
+
+release:
+  github:
+    owner: powerhome
+    name: keess
+  prerelease: auto
+  draft: false
+  name_template: "{{ .Tag }}"

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ ARCH := $(shell uname -m | sed 's/x86_64/amd64/;s/arm64/arm64/;s/aarch64/arm64/'
 GOBASE := $(shell pwd)
 GOBIN := $(GOBASE)/bin
 
-.PHONY: build docker-build coverage run docker-run create-local-clusters create-local-clusters-pac-v1 delete-local-clusters install-cilium-cli install-cilium-to-clusters install-keess setup-local-clusters setup-local-clusters-with-keess local-docker-run tests tests-e2e tests-python-e2e help
+.PHONY: build docker-build coverage run docker-run create-local-clusters create-local-clusters-pac-v1 delete-local-clusters install-cilium-cli install-cilium-to-clusters install-keess setup-local-clusters setup-local-clusters-with-keess local-docker-run tests tests-e2e tests-python-e2e tag-release help
 
 # Build the project
 build:
@@ -39,6 +39,32 @@ powerhome-build-and-publish:
 	docker build  --platform=linux/amd64 -f Dockerfile.kubeconfig-reloader -t powerhome/keess-kubeconfig-reloader:$(DOCKER_TAG) .
 	docker push powerhome/keess:$(DOCKER_TAG)
 	docker push powerhome/keess-kubeconfig-reloader:$(DOCKER_TAG)
+
+## Tag and push a release tag, triggering the GoReleaser release workflow which
+## builds and publishes both the keess and kubeconfig-reloader images to Harbor.
+## cmd/version.go and chart/Chart.yaml must already be bumped to VERSION and merged to main.
+## Run it with:
+##   make tag-release VERSION=1.4.2 [IGNORE_BRANCH_CHECK=true]
+tag-release:
+	@if [ -z "$(VERSION)" ]; then \
+		echo "VERSION must be set (e.g. make tag-release VERSION=1.4.2)"; exit 1; \
+	fi
+	@if ! echo "$(VERSION)" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$$'; then \
+		echo "VERSION must be a bare semver, e.g. 1.4.2 (this repo's tags have no 'v' prefix)"; exit 1; \
+	fi
+	@if [ "$(IGNORE_BRANCH_CHECK)" != "true" ]; then \
+		CURRENT_BRANCH=$$(git rev-parse --abbrev-ref HEAD); \
+		if [ "$$CURRENT_BRANCH" != "main" ]; then \
+			echo "Error: You must be on the 'main' branch to create releases. Current branch: $$CURRENT_BRANCH"; \
+			echo "Use IGNORE_BRANCH_CHECK=true to skip this check."; \
+			exit 1; \
+		fi; \
+	fi
+	@if ! grep -q "\"$(VERSION)\"" cmd/version.go; then \
+		echo "Warning: cmd/version.go does not appear to be bumped to $(VERSION). Did you forget to bump and merge it first?"; \
+	fi
+	git tag $(VERSION) -m "Release $(VERSION)"
+	git push origin $(VERSION)
 
 # New target for code coverage
 coverage:
@@ -185,6 +211,7 @@ help:
 	@echo "tests-python-e2e                - Run python e2e tests using docker (namespace sync focused)"
 	@echo "tests-all                       - Run all tests (unit + e2e)"
 	@echo "delete-local-clusters           - Delete the 2 local clusters created with Kind"
+	@echo "tag-release                     - Tag and push a release (VERSION=x.y.z), triggering the GoReleaser image release"
 	@echo "--------------------------------"
 	@echo "## Other Makefile commands:"
 	@echo "--------------------------------"
@@ -195,3 +222,4 @@ help:
 	@echo "install-keess                   - Install Keess on local clusters using Helm"
 	@echo "docker-run                      - Run the Docker image with .kube directory mounted"
 	@echo "local-docker-run                - Run the application locally using docker and pointing to the local cluster created with Kind"
+	@echo "powerhome-build-and-publish     - Build and publish Docker images to Docker Hub (DOCKER_TAG=x.y.z)"


### PR DESCRIPTION
## 🚀 What does this PR do?

Adds `.goreleaser.yaml` and `.github/workflows/release.yml`, modeled on `powerhome/pac-quota-controller`'s GoReleaser setup, to automate what's currently a manual release step. On every version tag push (e.g. `1.4.2`), this builds and pushes **both** the `keess` and `keess-kubeconfig-reloader` images to the internal Harbor registry (`image-registry.powerapp.cloud/keess/...`), and cuts a GitHub Release with auto-generated notes.

Runs on `self-hosted` (tracked separately: a `RunnerDeployment` is being added to `powerhome/pac` so this workflow has a runner that can reach the internal registry). Docker login uses `HARBOR_USERNAME`/`HARBOR_PASSWORD` secrets, following the same pattern as `powerhome/oncall-notifier`'s release workflow.

## 🔍 Why? (Context)

Today, publishing the `keess` and `kubeconfig-reloader` images is a manual step (`make powerhome-build-and-publish`) and Jenkins only builds the main `keess` image to the internal registry, never `kubeconfig-reloader`. This closes that gap and removes the manual publish step from the release checklist going forward.

## Checklist

- [ ] Update the Helm chart version and/or appVersion if those are changed
- [ ] Update cmd/version.go if code was changed
- [x] Publish the new keess image
- [x] Publish the new kubeconfig-reloader image
- [ ] Updated docs/ or /README.md if needed

## 🧪 How this was tested? And test results

- `goreleaser check` — config validates (only a non-blocking deprecation notice about `dockers` → `dockers_v2`, same as used by pac-quota-controller/oncall-notifier today).
- `goreleaser release --snapshot --clean --skip=publish,validate` locally — both Dockerfiles build successfully through GoReleaser's buildx path. The push step itself was not exercised locally (no Harbor credentials on this machine) — will be validated on the first real tag push once the `HARBOR_USERNAME`/`HARBOR_PASSWORD` secrets and the self-hosted runner are in place.

## ⚠️ Special care or coordination needed?

This workflow won't run successfully until:
1. `powerhome/pac` has a `RunnerDeployment` for `keess` (companion change, in progress)
2. `HARBOR_USERNAME`/`HARBOR_PASSWORD` repo secrets are added to `powerhome/keess`

Until then this is inert (no tags pushed yet), so safe to merge ahead of those.