### PR TITLE
[GOG-1931] Add repo-scoped hostRule for ci-kubed github-releases lookup

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,12 @@
   "extends": [
     "local>powerhome/renovate-config",
     "group:allNonMajor"
+  ],
+  "hostRules": [
+    {
+      "matchHost": "https://api.github.com/repos/powerhome/ci-kubed",
+      "hostType": "github-releases",
+      "token": "{{ secrets.CI_KUBED_READ_TOKEN }}"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Renovate can't resolve release info for `powerhome/ci-kubed` in this repo's Jenkinsfile pin (`library 'github.com/powerhome/ci-kubed@...'`). The job log shows:

```
"packageName":"powerhome/ci-kubed"
"err":{"message":"Could not resolve to a Repository with the name 'powerhome/ci-kubed'."}
"msg":"Datasource unknown error"
```

Root cause: `keess` is a **public** repo, so Mend issues its Renovate job a GitHub App token scoped only to `keess` itself, not the rest of the `powerhome` org. That token has no visibility into the private `ci-kubed` repo, so the `github-releases` GraphQL lookup fails. (`powerhome/example-rails-app`, which also depends on `ci-kubed`, works fine because it's private and gets a broader-scoped token.) There's nothing wrong with `ci-kubed`'s settings or the GitHub App's org installation — this is Mend's documented per-repo token scoping for public repos.

This PR adds a repo-scoped `hostRules` entry so `github-releases` lookups for `powerhome/ci-kubed` use a narrowly-scoped token instead of the (insufficient) default keess job token.

## Before this can take effect

- [x] Create a fine-grained GitHub PAT scoped only to `powerhome/ci-kubed`, permission `Contents: read`
- [x] Add it as a Mend-hosted repo secret for `keess` named `CI_KUBED_READ_TOKEN` (Mend portal → repo settings → Credentials — Mend cannot read GitHub Actions secrets)
- [x] Confirm `ci-kubed`'s release notes are safe to surface in a public `keess` PR body, since Renovate may include them once this works

See GOG-1931 for full findings and discussion.

## Test plan

- [x] After the `CI_KUBED_READ_TOKEN` secret is added, trigger a Renovate run from the dependency dashboard issue (#42) and confirm the `ci-kubed` lookup succeeds (should propose `v10.1.0` → `v10.4.0`) with no "Package lookup failures" warning