### PR TITLE
[GOG-1931] Use ci-kubed-read-token preset instead of inline hostRule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,13 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>powerhome/renovate-config",
+    "local>powerhome/renovate-config:ci-kubed-read-token",
     "group:allNonMajor"
-  ],
-  "hostRules": [
-    {
-      "matchHost": "https://api.github.com/repos/powerhome/ci-kubed",
-      "hostType": "github-releases",
-      "token": "{{ secrets.CI_KUBED_READ_TOKEN }}"
-    }
   ]
 }


### PR DESCRIPTION
## Summary

PR #121 added a repo-scoped `hostRules` entry directly to keess's renovate.json to fix `github-releases` lookups for the private `powerhome/ci-kubed` repo (public repos get a Mend token scoped to themselves only, so the lookup can't resolve `ci-kubed` without this).

That inline block is now available as a reusable preset in `powerhome/renovate-config`: `ci-kubed-read-token` (<a href="https://github.com/powerhome/renovate-config/pull/64">powerhome/renovate-config#64</a>). This swaps the inline `hostRules` for the preset so other public repos hitting the same issue (e.g. `playbook`) can reuse it instead of copy-pasting the block.

No behavior change, same `hostRules` entry, same `CI_KUBED_READ_TOKEN` Mend secret.

## Depends on

- [ ] <a href="https://github.com/powerhome/renovate-config/pull/64">powerhome/renovate-config#64</a> must merge first — the `ci-kubed-read-token` preset doesn't exist on renovate-config's main branch yet, so this PR isn't mergeable until then. Marking as draft for now.

## Context

<a href="https://runway.powerhrg.com/backlog_items/GOG-1931">GOG-1931</a>